### PR TITLE
Tests for TGW peering attachment

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -1,0 +1,324 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"log"
+	"testing"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_ec2_transit_gateway_peering_attachment", &resource.Sweeper{
+		Name: "aws_ec2_transit_gateway_peering_attachment",
+		F:    testSweepEc2TransitGatewayPeeringAttachments,
+	})
+}
+func testSweepEc2TransitGatewayPeeringAttachments(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+	input := &ec2.DescribeTransitGatewayAttachmentsInput{}
+	for {
+		output, err := conn.DescribeTransitGatewayAttachments(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Transit Gateway Peering Attachment sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving EC2 Transit Gateway Peering Attachments: %s", err)
+		}
+		for _, attachment := range output.TransitGatewayAttachments {
+			if aws.StringValue(attachment.ResourceType) != ec2.TransitGatewayAttachmentResourceTypeTgwPeering {
+				continue
+			}
+			if aws.StringValue(attachment.State) == ec2.TransitGatewayAttachmentStateDeleted {
+				continue
+			}
+			id := aws.StringValue(attachment.TransitGatewayAttachmentId)
+			input := &ec2.DeleteTransitGatewayPeeringAttachmentInput{
+				TransitGatewayAttachmentId: aws.String(id),
+			}
+			log.Printf("[INFO] Deleting EC2 Transit Gateway Peering Attachment: %s", id)
+			_, err := conn.DeleteTransitGatewayPeeringAttachment(input)
+			if isAWSErr(err, "InvalidTransitGatewayAttachmentID.NotFound", "") {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("error deleting EC2 Transit Gateway Peering Attachment (%s): %s", id, err)
+			}
+			if err := waitForEc2TransitGatewayPeeringAttachmentDeletion(conn, id); err != nil {
+				return fmt.Errorf("error waiting for EC2 Transit Gateway Peering Attachment (%s) deletion: %s", id, err)
+			}
+		}
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+	return nil
+}
+func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
+	var transitGatewayPeeringAttachment1 ec2.TransitGatewayPeeringAttachment
+	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
+	transitGatewayResourceName := "aws_ec2_transit_gateway.first"
+	transitGateway2ResourceName := "aws_ec2_transit_gateway.second"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment1),
+					resource.TestCheckResourceAttr(resourceName, "peer_account_id", "true"),
+					resource.TestCheckResourceAttr(resourceName, "peer_region", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", transitGateway2ResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccAWSEc2TransitGatewayPeeringAttachment_disappears(t *testing.T) {
+	var transitGatewayPeeringAttachment1 ec2.TransitGatewayPeeringAttachment
+	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment1),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentDisappears(&transitGatewayPeeringAttachment1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+func TestAccAWSEc2TransitGatewayPeeringAttachment_Tags(t *testing.T) {
+	var transitGatewayPeeringAttachment1, transitGatewayPeeringAttachment2, transitGatewayPeeringAttachment3 ec2.TransitGatewayPeeringAttachment
+	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags2("key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment2),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentNotRecreated(&transitGatewayPeeringAttachment1, &transitGatewayPeeringAttachment2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1("key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment3),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentNotRecreated(&transitGatewayPeeringAttachment2, &transitGatewayPeeringAttachment3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName string, transitGatewayPeeringAttachment *ec2.TransitGatewayPeeringAttachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EC2 Transit Gateway Peering Attachment ID is set")
+		}
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		attachment, err := ec2DescribeTransitGatewayPeeringAttachment(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if attachment == nil {
+			return fmt.Errorf("EC2 Transit Gateway Peering Attachment not found")
+		}
+		if aws.StringValue(attachment.State) != ec2.TransitGatewayAttachmentStateAvailable && aws.StringValue(attachment.State) != ec2.TransitGatewayAttachmentStatePendingAcceptance {
+			return fmt.Errorf("EC2 Transit Gateway Peering Attachment (%s) exists in non-available/pending acceptance (%s) state", rs.Primary.ID, aws.StringValue(attachment.State))
+		}
+		*transitGatewayPeeringAttachment = *attachment
+		return nil
+	}
+}
+func testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_transit_gateway_route_table" {
+			continue
+		}
+		peeringAttachment, err := ec2DescribeTransitGatewayPeeringAttachment(conn, rs.Primary.ID)
+		if isAWSErr(err, "InvalidTransitGatewayAttachmentID.NotFound", "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if peeringAttachment == nil {
+			continue
+		}
+		if aws.StringValue(peeringAttachment.State) != ec2.TransitGatewayAttachmentStateDeleted {
+			return fmt.Errorf("EC2 Transit Gateway Peering Attachment (%s) still exists in non-deleted (%s) state", rs.Primary.ID, aws.StringValue(peeringAttachment.State))
+		}
+	}
+	return nil
+}
+func testAccCheckAWSEc2TransitGatewayPeeringAttachmentDisappears(transitGatewayPeeringAttachment *ec2.TransitGatewayPeeringAttachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		input := &ec2.DeleteTransitGatewayPeeringAttachmentInput{
+			TransitGatewayAttachmentId: transitGatewayPeeringAttachment.TransitGatewayAttachmentId,
+		}
+		if _, err := conn.DeleteTransitGatewayPeeringAttachment(input); err != nil {
+			return err
+		}
+		return waitForEc2TransitGatewayPeeringAttachmentDeletion(conn, aws.StringValue(transitGatewayPeeringAttachment.TransitGatewayAttachmentId))
+	}
+}
+func testAccCheckAWSEc2TransitGatewayPeeringAttachmentNotRecreated(i, j *ec2.TransitGatewayPeeringAttachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.TransitGatewayAttachmentId) != aws.StringValue(j.TransitGatewayAttachmentId) {
+			return errors.New("EC2 Transit Gateway Peering Attachment was recreated")
+		}
+		return nil
+	}
+}
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfig() string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+data "aws_caller_identity" "second" {
+  provider = "aws.alternate"
+
+}
+
+resource "aws_ec2_transit_gateway" "first" {
+  provider = "aws"
+
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-first-Config"
+  }
+}
+
+resource "aws_ec2_transit_gateway" "second" {
+  provider = "aws.alternate"
+
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-second-Config"
+  }
+}
+
+// Create the Peering attachment in the first account...
+resource "aws_ec2_transit_gateway_peering_attachment" "example" {
+  peer_account_id         = "${data.aws_caller_identity.second.account_id}"
+  peer_region             = %[1]q
+  peer_transit_gateway_id = "${aws_ec2_transit_gateway.second.id}"
+  transit_gateway_id      = "${aws_ec2_transit_gateway.first.id}"
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-peering-attachment-Config"
+  }
+}
+`, testAccGetAlternateRegion())
+}
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1(tagKey1, tagValue1 string) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+data "aws_caller_identity" "second" {
+  provider = "aws.alternate"
+
+}
+
+resource "aws_ec2_transit_gateway" "first" {
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-first-ConfigTags1"
+  }
+}
+
+resource "aws_ec2_transit_gateway" "second" {
+  provider = "aws.alternate"
+
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-second-ConfigTags1"
+  }
+}
+
+// Create the Peering attachment in the first account...
+resource "aws_ec2_transit_gateway_peering_attachment" "example" {
+  peer_account_id         = "${data.aws_caller_identity.second.account_id}"
+  peer_region             = %[3]q
+  peer_transit_gateway_id = "${aws_ec2_transit_gateway.second.id}"
+  transit_gateway_id      = "${aws_ec2_transit_gateway.first.id}"
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1, testAccGetAlternateRegion())
+}
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+data "aws_caller_identity" "second" {
+  provider = "aws.alternate"
+
+}
+
+resource "aws_ec2_transit_gateway" "first" {
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway-first-ConfigTags2"
+  }
+}
+
+resource "aws_ec2_transit_gateway" "second" {
+  provider = "aws.alternate"
+
+  tags = {
+    Name = "tf-acc-test-ec2-transit-gateway1-second-ConfigTags2"
+  }
+}
+
+// Create the Peering attachment in the first account...
+resource "aws_ec2_transit_gateway_peering_attachment" "example" {
+  peer_account_id         = "${data.aws_caller_identity.second.account_id}"
+  peer_region             = %[5]q
+  peer_transit_gateway_id = "${aws_ec2_transit_gateway.second.id}"
+  transit_gateway_id      = "${aws_ec2_transit_gateway.first.id}"
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2, testAccGetAlternateRegion())
+}

--- a/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_ec2_transit_gateway_peering_attachment"
+description: |-
+  Manages an EC2 Transit Gateway Peering Attachment
+---
+
+# Resource: aws_ec2_transit_gateway_peering_attachment
+
+Manages an EC2 Transit Gateway Peering Attachment. For examples of custom route table association and propagation, see the EC2 Transit Gateway Networking Examples Guide.
+
+## Example Usage
+
+```hcl
+resource "aws_ec2_transit_gateway_peering_attachment" "example" {
+  peer_account_id             = "00000000000"
+  peer_region                 = "us-east-2"
+  peer_transit_gateway_id     = "tgw-00000000000000000"
+  tags                        = "example"
+  transit_gateway_id          = "tgw-00000000000000000"
+}
+```
+
+A full example of how to create a Transit Gateway in one AWS account, share it with a second AWS account, and attach a VPC in the second account to the Transit Gateway via the `aws_ec2_transit_gateway_vpc_attachment` and `aws_ec2_transit_gateway_vpc_attachment_accepter` resources can be found in [the `./examples/transit-gateway-cross-account-vpc-attachment` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/transit-gateway-cross-account-vpc-attachment).
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `peer_account_id` - (Required) Account ID of EC2 Transit Gateway to peer with.
+* `peer_region` - (Required) Region of EC2 Transit Gateway to peer with.
+* `peer_transit_gateway_id` - (Required) Identifier of EC2 Transit Gateway to peer with.
+* `tags` - (Optional) Key-value tags for the EC2 Transit Gateway Peering Attachment.
+* `transit_gateway_id` - (Required) Identifier of EC2 Transit Gateway.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - EC2 Transit Gateway Attachment identifier
+
+## Import
+
+`aws_ec2_transit_gateway_peering_attachment` can be imported by using the EC2 Transit Gateway Attachment identifier, e.g.
+
+```bash
+$ terraform import aws_ec2_transit_gateway_peering_attachment.example tgw-attach-12345678
+```


### PR DESCRIPTION
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayPeeringAttachment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayPeeringAttachment -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayPeeringAttachment_basic
=== PAUSE TestAccAWSEc2TransitGatewayPeeringAttachment_basic
=== RUN   TestAccAWSEc2TransitGatewayPeeringAttachment_disappears
=== PAUSE TestAccAWSEc2TransitGatewayPeeringAttachment_disappears
=== RUN   TestAccAWSEc2TransitGatewayPeeringAttachment_Tags
=== PAUSE TestAccAWSEc2TransitGatewayPeeringAttachment_Tags
=== CONT  TestAccAWSEc2TransitGatewayPeeringAttachment_basic
=== CONT  TestAccAWSEc2TransitGatewayPeeringAttachment_Tags
=== CONT  TestAccAWSEc2TransitGatewayPeeringAttachment_disappears
--- FAIL: TestAccAWSEc2TransitGatewayPeeringAttachment_basic (166.50s)
    testing.go:635: Step 0 error: Check failed: Check 1/6 error: Not found: aws_ec2_transit_gateway_peering_attachment.test
    testing.go:696: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: config is invalid: 2 problems:
        
        - Provider configuration not present: To work with aws_ec2_transit_gateway.second its original provider configuration at provider.aws.alternate is required, but it has been removed. This occurs when a provider configuration is removed while objects created by that provider still exist in the state. Re-add the provider configuration to destroy aws_ec2_transit_gateway.second, after which you can remove the provider configuration again.
        - Provider configuration not present: To work with data.aws_caller_identity.second its original provider configuration at provider.aws.alternate is required, but it has been removed. This occurs when a provider configuration is removed while objects created by that provider still exist in the state. Re-add the provider configuration to destroy data.aws_caller_identity.second, after which you can remove the provider configuration again.
        
        State: aws_ec2_transit_gateway.first:
          ID = tgw-x1x1x1x1x1x1x1x1x
          provider = provider.aws
          amazon_side_asn = 64512
          arn = arn:aws:ec2:us-west-2:012345678901:transit-gateway/tgw-x1x1x1x1x1x1x1x1x
          association_default_route_table_id = tgw-rtb-x1x1x1x1x1x1x1x1x
          auto_accept_shared_attachments = disable
          default_route_table_association = enable
          default_route_table_propagation = enable
          description = 
          dns_support = enable
          owner_id = 012345678901
          propagation_default_route_table_id = tgw-rtb-x1x1x1x1x1x1x1x1x
          tags.% = 1
          tags.Name = tf-acc-test-ec2-transit-gateway-first-Config
          vpn_ecmp_support = enable
        aws_ec2_transit_gateway.second:
          ID = tgw-x2x2x2x2x2x2x2x2x
          provider = provider.aws.alternate
          amazon_side_asn = 64512
          arn = arn:aws:ec2:us-east-1:012345678901:transit-gateway/tgw-x2x2x2x2x2x2x2x2x
          association_default_route_table_id = tgw-rtb-x2x2x2x2x2x2x2x2x
          auto_accept_shared_attachments = disable
          default_route_table_association = enable
          default_route_table_propagation = enable
          description = 
          dns_support = enable
          owner_id = 012345678901
          propagation_default_route_table_id = tgw-rtb-x2x2x2x2x2x2x2x2x
          tags.% = 1
          tags.Name = tf-acc-test-ec2-transit-gateway-second-Config
          vpn_ecmp_support = enable
        aws_ec2_transit_gateway_peering_attachment.example:
          ID = tgw-attach-0960a65acef1bca0c
          provider = provider.aws
          peer_account_id = 012345678901
          peer_region = us-east-1
          peer_transit_gateway_id = tgw-x2x2x2x2x2x2x2x2x
          tags.% = 1
          tags.Name = tf-acc-test-ec2-transit-gateway-peering-attachment-Config
          transit_gateway_id = tgw-x1x1x1x1x1x1x1x1x
        
          Dependencies:
            aws_ec2_transit_gateway.first
            aws_ec2_transit_gateway.second
            data.aws_caller_identity.second
        data.aws_caller_identity.second:
          ID = 2019-12-24 13:10:46.27799 +0000 UTC
          provider = provider.aws.alternate
          account_id = 012345678901
          arn = arn:aws:sts::012345678901:assumed-role/xxxxx
          user_id = AROARBTZVYAKHZMQ5BU6Q:scripted-assume-role
--- FAIL: TestAccAWSEc2TransitGatewayPeeringAttachment_Tags (171.59s)
    testing.go:635: Step 0 error: Check failed: Check 1/3 error: Not found: aws_ec2_transit_gateway_peering_attachment.test
    testing.go:696: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: error deleting EC2 Transit Gateway: IncorrectState: tgw-x3x3x3x3x3x3x3x3x has non-deleted Transit Gateway Cross Region Peering Attachments: tgw-attach-x4x4x4x4x4x4x4x4x.
                status code: 400, request id: 046caa36-ca25-4a30-88fd-13a9064adb2f
        
        State: aws_ec2_transit_gateway.second:
          ID = tgw-x3x3x3x3x3x3x3x3x
          provider = provider.aws.alternate
          amazon_side_asn = 64512
          arn = arn:aws:ec2:us-east-1:012345678901:transit-gateway/tgw-x3x3x3x3x3x3x3x3x
          association_default_route_table_id = tgw-rtb-x3x3x3x3x3x3x3x3x
          auto_accept_shared_attachments = disable
          default_route_table_association = enable
          default_route_table_propagation = enable
          description = 
          dns_support = enable
          owner_id = 012345678901
          propagation_default_route_table_id = tgw-rtb-x3x3x3x3x3x3x3x3x
          tags.% = 1
          tags.Name = tf-acc-test-ec2-transit-gateway-second-ConfigTags1
          vpn_ecmp_support = enable
--- FAIL: TestAccAWSEc2TransitGatewayPeeringAttachment_disappears (194.91s)
    testing.go:635: Step 0 error: Check failed: Check 1/2 error: Not found: aws_ec2_transit_gateway_peering_attachment.test
    testing.go:696: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: error deleting EC2 Transit Gateway: IncorrectState: tgw-x5x5x5x5x5x5x5x5x has non-deleted Transit Gateway Cross Region Peering Attachments: tgw-attach-x6x6x6x6x6x6x6x6x.
                status code: 400, request id: b810b053-9d45-4262-a4fc-493b925385e4
        
        State: aws_ec2_transit_gateway.first:
          ID = tgw-x5x5x5x5x5x5x5x5x
          provider = provider.aws
          amazon_side_asn = 64512
          arn = arn:aws:ec2:us-west-2:012345678901:transit-gateway/tgw-x5x5x5x5x5x5x5x5x
          association_default_route_table_id = tgw-rtb-x5x5x5x5x5x5x5x5x
          auto_accept_shared_attachments = disable
          default_route_table_association = enable
          default_route_table_propagation = enable
          description = 
          dns_support = enable
          owner_id = 012345678901
          propagation_default_route_table_id = tgw-rtb-x5x5x5x5x5x5x5x5x
          tags.% = 1
          tags.Name = tf-acc-test-ec2-transit-gateway-first-Config
          vpn_ecmp_support = enable
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       195.809s
FAIL
make: *** [testacc] Error 1
```
