### PR TITLE
r/aws_ec2_transit_gateway_peering_attachment: Get acceptance tests pa…

### DIFF
--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -584,11 +584,12 @@ func waitForEc2TransitGatewayPeeringAttachmentDeletion(conn *ec2.EC2, transitGat
 		Pending: []string{
 			ec2.TransitGatewayAttachmentStateAvailable,
 			ec2.TransitGatewayAttachmentStateDeleting,
+			ec2.TransitGatewayAttachmentStatePendingAcceptance,
+			ec2.TransitGatewayAttachmentStateRejected,
 		},
-		Target:         []string{ec2.TransitGatewayAttachmentStateDeleted},
-		Refresh:        ec2TransitGatewayVpcAttachmentRefreshFunc(conn, transitGatewayAttachmentID),
-		Timeout:        10 * time.Minute,
-		NotFoundChecks: 1,
+		Target:  []string{ec2.TransitGatewayAttachmentStateDeleted},
+		Refresh: ec2TransitGatewayPeeringAttachmentRefreshFunc(conn, transitGatewayAttachmentID),
+		Timeout: 10 * time.Minute,
 	}
 
 	log.Printf("[DEBUG] Waiting for EC2 Transit Gateway Peering Attachment (%s) deletion", transitGatewayAttachmentID)
@@ -597,20 +598,6 @@ func waitForEc2TransitGatewayPeeringAttachmentDeletion(conn *ec2.EC2, transitGat
 	if isResourceNotFoundError(err) {
 		return nil
 	}
-
-	return err
-}
-
-func waitForEc2TransitGatewayPeeringAttachmentUpdate(conn *ec2.EC2, transitGatewayAttachmentID string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.TransitGatewayAttachmentStateModifying},
-		Target:  []string{ec2.TransitGatewayAttachmentStateAvailable},
-		Refresh: ec2TransitGatewayVpcAttachmentRefreshFunc(conn, transitGatewayAttachmentID),
-		Timeout: 10 * time.Minute,
-	}
-
-	log.Printf("[DEBUG] Waiting for EC2 Transit Gateway Peering Attachment (%s) availability", transitGatewayAttachmentID)
-	_, err := stateConf.WaitForState()
 
 	return err
 }

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -1,14 +1,16 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"log"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func init() {
@@ -17,74 +19,95 @@ func init() {
 		F:    testSweepEc2TransitGatewayPeeringAttachments,
 	})
 }
+
 func testSweepEc2TransitGatewayPeeringAttachments(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*AWSClient).ec2conn
-	input := &ec2.DescribeTransitGatewayAttachmentsInput{}
+	input := &ec2.DescribeTransitGatewayPeeringAttachmentsInput{}
+
 	for {
-		output, err := conn.DescribeTransitGatewayAttachments(input)
+		output, err := conn.DescribeTransitGatewayPeeringAttachments(input)
+
 		if testSweepSkipSweepError(err) {
 			log.Printf("[WARN] Skipping EC2 Transit Gateway Peering Attachment sweep for %s: %s", region, err)
 			return nil
 		}
+
 		if err != nil {
 			return fmt.Errorf("error retrieving EC2 Transit Gateway Peering Attachments: %s", err)
 		}
-		for _, attachment := range output.TransitGatewayAttachments {
-			if aws.StringValue(attachment.ResourceType) != ec2.TransitGatewayAttachmentResourceTypeTgwPeering {
+
+		for _, transitGatewayPeeringAttachment := range output.TransitGatewayPeeringAttachments {
+			if aws.StringValue(transitGatewayPeeringAttachment.State) == ec2.TransitGatewayAttachmentStateDeleted {
 				continue
 			}
-			if aws.StringValue(attachment.State) == ec2.TransitGatewayAttachmentStateDeleted {
-				continue
-			}
-			id := aws.StringValue(attachment.TransitGatewayAttachmentId)
+
+			id := aws.StringValue(transitGatewayPeeringAttachment.TransitGatewayAttachmentId)
+
 			input := &ec2.DeleteTransitGatewayPeeringAttachmentInput{
 				TransitGatewayAttachmentId: aws.String(id),
 			}
+
 			log.Printf("[INFO] Deleting EC2 Transit Gateway Peering Attachment: %s", id)
 			_, err := conn.DeleteTransitGatewayPeeringAttachment(input)
+
 			if isAWSErr(err, "InvalidTransitGatewayAttachmentID.NotFound", "") {
 				continue
 			}
+
 			if err != nil {
 				return fmt.Errorf("error deleting EC2 Transit Gateway Peering Attachment (%s): %s", id, err)
 			}
+
 			if err := waitForEc2TransitGatewayPeeringAttachmentDeletion(conn, id); err != nil {
 				return fmt.Errorf("error waiting for EC2 Transit Gateway Peering Attachment (%s) deletion: %s", id, err)
 			}
 		}
+
 		if aws.StringValue(output.NextToken) == "" {
 			break
 		}
+
 		input.NextToken = output.NextToken
 	}
+
 	return nil
 }
+
 func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
-	var transitGatewayPeeringAttachment1 ec2.TransitGatewayPeeringAttachment
+	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
+	var providers []*schema.Provider
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
-	transitGatewayResourceName := "aws_ec2_transit_gateway.first"
-	transitGateway2ResourceName := "aws_ec2_transit_gateway.second"
+	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
+	transitGatewayResourceNamePeer := "aws_ec2_transit_gateway.peer"
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfig(),
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment1),
-					resource.TestCheckResourceAttr(resourceName, "peer_account_id", "true"),
-					resource.TestCheckResourceAttr(resourceName, "peer_region", "true"),
-					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", transitGateway2ResourceName, "id"),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
+					testAccCheckResourceAttrAccountID(resourceName, "peer_account_id"),
+					resource.TestCheckResourceAttr(resourceName, "peer_region", testAccGetAlternateRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", transitGatewayResourceNamePeer, "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
 				),
 			},
 			{
+				Config:            testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_sameAccount(rName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -92,233 +115,221 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccAWSEc2TransitGatewayPeeringAttachment_disappears(t *testing.T) {
-	var transitGatewayPeeringAttachment1 ec2.TransitGatewayPeeringAttachment
+	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
+	var providers []*schema.Provider
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfig(),
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment1),
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentDisappears(&transitGatewayPeeringAttachment1),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentDisappears(&transitGatewayPeeringAttachment),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
-func TestAccAWSEc2TransitGatewayPeeringAttachment_Tags(t *testing.T) {
-	var transitGatewayPeeringAttachment1, transitGatewayPeeringAttachment2, transitGatewayPeeringAttachment3 ec2.TransitGatewayPeeringAttachment
+
+func TestAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T) {
+	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
+	var providers []*schema.Provider
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1("key1", "value1"),
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1_sameAccount(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment1),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
+				Config:            testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1_sameAccount(rName, "key1", "value1"),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags2("key1", "value1updated", "key2", "value2"),
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags2_sameAccount(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment2),
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentNotRecreated(&transitGatewayPeeringAttachment1, &transitGatewayPeeringAttachment2),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
 			},
 			{
-				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1("key2", "value2"),
+				Config: testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment3),
-					testAccCheckAWSEc2TransitGatewayPeeringAttachmentNotRecreated(&transitGatewayPeeringAttachment2, &transitGatewayPeeringAttachment3),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName, &transitGatewayPeeringAttachment),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
 	})
 }
+
 func testAccCheckAWSEc2TransitGatewayPeeringAttachmentExists(resourceName string, transitGatewayPeeringAttachment *ec2.TransitGatewayPeeringAttachment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
+
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No EC2 Transit Gateway Peering Attachment ID is set")
 		}
+
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
 		attachment, err := ec2DescribeTransitGatewayPeeringAttachment(conn, rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
+
 		if attachment == nil {
 			return fmt.Errorf("EC2 Transit Gateway Peering Attachment not found")
 		}
+
 		if aws.StringValue(attachment.State) != ec2.TransitGatewayAttachmentStateAvailable && aws.StringValue(attachment.State) != ec2.TransitGatewayAttachmentStatePendingAcceptance {
 			return fmt.Errorf("EC2 Transit Gateway Peering Attachment (%s) exists in non-available/pending acceptance (%s) state", rs.Primary.ID, aws.StringValue(attachment.State))
 		}
+
 		*transitGatewayPeeringAttachment = *attachment
+
 		return nil
 	}
 }
+
 func testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_ec2_transit_gateway_route_table" {
+		if rs.Type != "aws_ec2_transit_gateway_peering_attachment" {
 			continue
 		}
+
 		peeringAttachment, err := ec2DescribeTransitGatewayPeeringAttachment(conn, rs.Primary.ID)
+
 		if isAWSErr(err, "InvalidTransitGatewayAttachmentID.NotFound", "") {
 			continue
 		}
+
 		if err != nil {
 			return err
 		}
+
 		if peeringAttachment == nil {
 			continue
 		}
+
 		if aws.StringValue(peeringAttachment.State) != ec2.TransitGatewayAttachmentStateDeleted {
 			return fmt.Errorf("EC2 Transit Gateway Peering Attachment (%s) still exists in non-deleted (%s) state", rs.Primary.ID, aws.StringValue(peeringAttachment.State))
 		}
 	}
+
 	return nil
 }
+
 func testAccCheckAWSEc2TransitGatewayPeeringAttachmentDisappears(transitGatewayPeeringAttachment *ec2.TransitGatewayPeeringAttachment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
 		input := &ec2.DeleteTransitGatewayPeeringAttachmentInput{
 			TransitGatewayAttachmentId: transitGatewayPeeringAttachment.TransitGatewayAttachmentId,
 		}
+
 		if _, err := conn.DeleteTransitGatewayPeeringAttachment(input); err != nil {
 			return err
 		}
+
 		return waitForEc2TransitGatewayPeeringAttachmentDeletion(conn, aws.StringValue(transitGatewayPeeringAttachment.TransitGatewayAttachmentId))
 	}
 }
-func testAccCheckAWSEc2TransitGatewayPeeringAttachmentNotRecreated(i, j *ec2.TransitGatewayPeeringAttachment) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.StringValue(i.TransitGatewayAttachmentId) != aws.StringValue(j.TransitGatewayAttachmentId) {
-			return errors.New("EC2 Transit Gateway Peering Attachment was recreated")
-		}
-		return nil
-	}
-}
-func testAccAWSEc2TransitGatewayPeeringAttachmentConfig() string {
+
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfig_sameAccount_base(rName string) string {
 	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
-data "aws_caller_identity" "second" {
-  provider = "aws.alternate"
-
-}
-
-resource "aws_ec2_transit_gateway" "first" {
-  provider = "aws"
-
+resource "aws_ec2_transit_gateway" "test" {
   tags = {
-    Name = "tf-acc-test-ec2-transit-gateway-first-Config"
+    Name = %[1]q
   }
 }
 
-resource "aws_ec2_transit_gateway" "second" {
+resource "aws_ec2_transit_gateway" "peer" {
   provider = "aws.alternate"
 
   tags = {
-    Name = "tf-acc-test-ec2-transit-gateway-second-Config"
+    Name = %[1]q
   }
 }
+`, rName)
+}
 
-// Create the Peering attachment in the first account...
-resource "aws_ec2_transit_gateway_peering_attachment" "example" {
-  peer_account_id         = "${data.aws_caller_identity.second.account_id}"
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_sameAccount(rName string) string {
+	return testAccAWSEc2TransitGatewayPeeringAttachmentConfig_sameAccount_base(rName) + fmt.Sprintf(`
+resource "aws_ec2_transit_gateway_peering_attachment" "test" {
   peer_region             = %[1]q
-  peer_transit_gateway_id = "${aws_ec2_transit_gateway.second.id}"
-  transit_gateway_id      = "${aws_ec2_transit_gateway.first.id}"
-  tags = {
-    Name = "tf-acc-test-ec2-transit-gateway-peering-attachment-Config"
-  }
+  peer_transit_gateway_id = "${aws_ec2_transit_gateway.peer.id}"
+  transit_gateway_id      = "${aws_ec2_transit_gateway.test.id}"
 }
 `, testAccGetAlternateRegion())
 }
-func testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1(tagKey1, tagValue1 string) string {
-	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
-data "aws_caller_identity" "second" {
-  provider = "aws.alternate"
 
-}
-
-resource "aws_ec2_transit_gateway" "first" {
-  tags = {
-    Name = "tf-acc-test-ec2-transit-gateway-first-ConfigTags1"
-  }
-}
-
-resource "aws_ec2_transit_gateway" "second" {
-  provider = "aws.alternate"
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags1_sameAccount(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSEc2TransitGatewayPeeringAttachmentConfig_sameAccount_base(rName) + fmt.Sprintf(`
+resource "aws_ec2_transit_gateway_peering_attachment" "test" {
+  peer_region             = %[1]q
+  peer_transit_gateway_id = "${aws_ec2_transit_gateway.peer.id}"
+  transit_gateway_id      = "${aws_ec2_transit_gateway.test.id}"
 
   tags = {
-    Name = "tf-acc-test-ec2-transit-gateway-second-ConfigTags1"
+    Name  = %[2]q
+    %[3]s = %[4]q
   }
 }
-
-// Create the Peering attachment in the first account...
-resource "aws_ec2_transit_gateway_peering_attachment" "example" {
-  peer_account_id         = "${data.aws_caller_identity.second.account_id}"
-  peer_region             = %[3]q
-  peer_transit_gateway_id = "${aws_ec2_transit_gateway.second.id}"
-  transit_gateway_id      = "${aws_ec2_transit_gateway.first.id}"
-  tags = {
-    %[1]q = %[2]q
-  }
-}
-`, tagKey1, tagValue1, testAccGetAlternateRegion())
-}
-func testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
-data "aws_caller_identity" "second" {
-  provider = "aws.alternate"
-
+`, testAccGetAlternateRegion(), rName, tagKey1, tagValue1)
 }
 
-resource "aws_ec2_transit_gateway" "first" {
-  tags = {
-    Name = "tf-acc-test-ec2-transit-gateway-first-ConfigTags2"
-  }
-}
-
-resource "aws_ec2_transit_gateway" "second" {
-  provider = "aws.alternate"
+func testAccAWSEc2TransitGatewayPeeringAttachmentConfigTags2_sameAccount(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSEc2TransitGatewayPeeringAttachmentConfig_sameAccount_base(rName) + fmt.Sprintf(`
+resource "aws_ec2_transit_gateway_peering_attachment" "test" {
+  peer_region             = %[1]q
+  peer_transit_gateway_id = "${aws_ec2_transit_gateway.peer.id}"
+  transit_gateway_id      = "${aws_ec2_transit_gateway.test.id}"
 
   tags = {
-    Name = "tf-acc-test-ec2-transit-gateway1-second-ConfigTags2"
+    Name  = %[2]q
+    %[3]s = %[4]q
+    %[5]s = %[6]q
   }
 }
-
-// Create the Peering attachment in the first account...
-resource "aws_ec2_transit_gateway_peering_attachment" "example" {
-  peer_account_id         = "${data.aws_caller_identity.second.account_id}"
-  peer_region             = %[5]q
-  peer_transit_gateway_id = "${aws_ec2_transit_gateway.second.id}"
-  transit_gateway_id      = "${aws_ec2_transit_gateway.first.id}"
-  tags = {
-    %[1]q = %[2]q
-    %[3]q = %[4]q
-  }
-}
-`, tagKey1, tagValue1, tagKey2, tagValue2, testAccGetAlternateRegion())
+`, testAccGetAlternateRegion(), rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -20,6 +20,7 @@ func init() {
 		Dependencies: []string{
 			"aws_dx_gateway_association",
 			"aws_ec2_transit_gateway_vpc_attachment",
+			"aws_ec2_transit_gateway_peering_attachment",
 			"aws_vpn_connection",
 		},
 	})

--- a/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # Resource: aws_ec2_transit_gateway_peering_attachment
 
-Manages an EC2 Transit Gateway Peering Attachment, supporting the following AWS Regions: US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), and Europe (Ireland). For examples of custom route table association and propagation, see the EC2 Transit Gateway Networking Examples Guide.
+Manages an EC2 Transit Gateway Peering Attachment.
+For examples of custom route table association and propagation, see the EC2 Transit Gateway Networking Examples Guide.
 
 ## Example Usage
 
@@ -21,7 +22,8 @@ resource "aws_ec2_transit_gateway_peering_attachment" "example" {
 
   tags = {
     Name = "Example cross-account attachment"
-  }}
+  }
+}
 ```
 
 A full example of how to create a Transit Gateway in one AWS account, share it with a second AWS account, and attach a to a Transit Gateway in the second account via the `aws_ec2_transit_gateway_peering_attachment` resource can be found in [the `./examples/transit-gateway-cross-account-peering-attachment` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/transit-gateway-cross-account-peering-attachment).
@@ -30,7 +32,7 @@ A full example of how to create a Transit Gateway in one AWS account, share it w
 
 The following arguments are supported:
 
-* `peer_account_id` - (Required) Account ID of EC2 Transit Gateway to peer with.
+* `peer_account_id` - (Optional) Account ID of EC2 Transit Gateway to peer with. Defaults to the account ID the [AWS provider][1] is currently connected to.
 * `peer_region` - (Required) Region of EC2 Transit Gateway to peer with.
 * `peer_transit_gateway_id` - (Required) Identifier of EC2 Transit Gateway to peer with.
 * `tags` - (Optional) Key-value tags for the EC2 Transit Gateway Peering Attachment.
@@ -46,6 +48,8 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_ec2_transit_gateway_peering_attachment` can be imported by using the EC2 Transit Gateway Attachment identifier, e.g.
 
-```bash
+```sh
 $ terraform import aws_ec2_transit_gateway_peering_attachment.example tgw-attach-12345678
 ```
+
+[1]: /docs/providers/aws/index.html


### PR DESCRIPTION
…ssing.

Implement @ewbankkit's work for transit gateway peering:

https://github.com/terraform-providers/terraform-provider-aws/pull/11162#issuecomment-573048782
   
- The resources were left dangling because the Config value was not set on the import test step as required for cross-region acceptance tests and documented in the Contributing guide
- The test case was actually failing because of a resource name mismatch (.example vs. .test)
- Because of the dangling resources I ran the test sweeper and add it as a dependency to the aws_ec2_transit_gateway test sweeper
- I made peer_account_id optional (defaults to current account ID) as for VPC peering connections and also made all the other attributes (except tags) ForceNew: true which means that the Update method only deals with changes to tags
- Tidied up various other things on the way