### PR TITLE
error sweeper & TGW deletion retryable error handling for TGW peering

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway.go
+++ b/aws/resource_aws_ec2_transit_gateway.go
@@ -231,6 +231,10 @@ func resourceAwsEc2TransitGatewayDelete(d *schema.ResourceData, meta interface{}
 			return resource.RetryableError(err)
 		}
 
+		if isAWSErr(err, "IncorrectState", "has non-deleted Transit Gateway Cross Region Peering Attachments") {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -153,10 +152,6 @@ func resourceAwsEc2TransitGatewayPeeringAttachmentDelete(d *schema.ResourceData,
 	if err := waitForEc2TransitGatewayPeeringAttachmentDeletion(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for EC2 Transit Gateway Peering Attachment (%s) deletion: %s", d.Id(), err)
 	}
-
-	// When the deleted state is returned by API - the transit gateways aren't yet aware of this deleted state.
-	// thus the transit gateways cannot be deleted for a short period of time
-	time.Sleep(90 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION
sweep errors as per - https://github.com/terraform-providers/terraform-provider-aws/pull/11162#discussion_r396029540

When deleting a TGW - allow retry for `non-deleted TGW X-Region Peering Attachments`  https://github.com/terraform-providers/terraform-provider-aws/pull/11162#discussion_r405558305